### PR TITLE
Add scroll events tracking for Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,18 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <!-- GOOGLE ANALYTICS -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-XXXXXXXX-X, 'auto');
+      ga('send', 'pageview');
+
+    </script>
+
 </head>
 
 <body id="page-top" class="index">
@@ -653,6 +665,9 @@
     <!-- Contact Form JavaScript -->
     <script src="js/jqBootstrapValidation.js"></script>
     <script src="js/contact_me.js"></script>
+
+    <!-- Visibility to enhance google event analytics -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/visibility.js/1.2.1/visibility.min.js"></script>
 
     <!-- Custom Theme JavaScript -->
     <script src="js/agency.js"></script>

--- a/js/agency.js
+++ b/js/agency.js
@@ -20,6 +20,51 @@ $('body').scrollspy({
     target: '.navbar-fixed-top'
 })
 
+// Event tracking for google analytics
+// inspired by http://cutroni.com/blog/2012/02/21/advanced-content-tracking-with-google-analytics-part-1/
+var timer = 0;
+var callBackTime = 700;
+var debugTracker = true; //set this to false in production
+var currentItem = "";
+var score = 0;
+var order = 1;
+// update score (number of seconds in active view)
+Visibility.every(1000, function () {
+    score++;
+});
+function trackLocation() {
+    if(!debugTracker) {
+	ga('send', {
+	    'hitType': 'event',
+	    'eventCategory': 'Navigation (order)',
+	    'eventAction': '#'+currentItem,
+	    'eventValue': order
+	});
+	ga('send', {
+	    'hitType': 'event',
+	    'eventCategory': 'Duration (sec.)',
+	    'eventAction': '#'+currentItem,
+	    'eventValue': score
+	});
+    } else {
+	console.log("You have viewed: #" + currentItem + " (order " + order + ", " + score + " sec.)");
+    }
+    // determine current location
+    currentItem = $(".nav li.active > a").text();
+    // reset score
+    score = 0;
+    order++;
+}
+$('body').on('activate.bs.scrollspy', function () {
+    // Use a buffer so we don't call track location too often (high speed scroll)
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(trackLocation, callBackTime);
+})
+window.onbeforeunload = function() {
+    trackLocation();
+    return null;
+}
+
 // Closes the Responsive Menu on Menu Item Click
 $('.navbar-collapse ul li a').click(function() {
     $('.navbar-toggle:visible').click();


### PR DESCRIPTION
Hi! 
Firstly thanks for the great template. 
Please find in this pull request what I've put in place to get proper analytics on my website. Hope this can be useful.
Thibaut.
## 

This is to compensate uninformative analytics on single page websites and aims at providing the same vital information as for normal website.
- the time spent in each section is sent to GA when exiting the section (category 'Duration')
- the last section is also tracked when the page is closed
- the duration only takes into account time when the website is active (not in background tab)
- the order in which sections are visited is sent at the same time (category 'Navigation')

Notes:
- Tracking code should be changed in index.html (UA-XXXXXXXX-X) to your own.
- debugTracker should be sent to false in agency.js for production use
- implementation leverages bootstrap scrollspy events and visibility.js better durations
