### PR TITLE
Class name fixed

### DIFF
--- a/js/cbpAnimatedHeader.min.js
+++ b/js/cbpAnimatedHeader.min.js
@@ -8,4 +8,4 @@
  * Copyright 2013, Codrops
  * http://www.codrops.com
  */
-var cbpAnimatedHeader=(function(){var b=document.documentElement,g=document.querySelector(".navbar-default"),e=false,a=300;function f(){window.addEventListener("scroll",function(h){if(!e){e=true;setTimeout(d,250)}},false)}function d(){var h=c();if(h>=a){classie.add(g,"cbp-af-header-shrink")}else{classie.remove(g,"cbp-af-header-shrink")}e=false}function c(){return window.pageYOffset||b.scrollTop}f()})();
+var cbpAnimatedHeader=(function(){var b=document.documentElement,g=document.querySelector(".navbar-default"),e=false,a=300;function f(){window.addEventListener("scroll",function(h){if(!e){e=true;setTimeout(d,250)}},false)}function d(){var h=c();if(h>=a){classie.add(g,"navbar-shrink")}else{classie.remove(g,"navbar-shrink")}e=false}function c(){return window.pageYOffset||b.scrollTop}f()})();


### PR DESCRIPTION
I think the class name used in unminified version of js file was changed to fit environment.
But that name must be the same in the minified version in order to be usefull.

So I changed the name from [the original](https://github.com/codrops/AnimatedHeader/blob/master/js/cbpAnimatedHeader.js#L30) `cbp-af-header-shrink` to `navbar-shrink`
