### PR TITLE
Fix to collapse navbar on page reloads

### DIFF
--- a/js/agency.js
+++ b/js/agency.js
@@ -4,6 +4,14 @@
  * For details, see http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+function hideOnRefresh() {
+    console.log($(".navbar").offset().top);
+    if ($(".navbar").offset().top > 50) {
+        $(".navbar-fixed-top").addClass("navbar-collapse navbar-shrink");
+    } else {
+        $(".navbar-fixed-top").removeClass("navbar-collapse navbar-shrink");
+    }
+}
 // jQuery for page scrolling feature - requires jQuery Easing plugin
 $(function() {
     $('a.page-scroll').bind('click', function(event) {
@@ -23,4 +31,12 @@ $('body').scrollspy({
 // Closes the Responsive Menu on Menu Item Click
 $('.navbar-collapse ul li a').click(function() {
     $('.navbar-toggle:visible').click();
+});
+
+$(document).ready(function() {
+    hideOnRefresh();
+});
+
+$(window).scroll(function() {
+    hideOnRefresh();
 });


### PR DESCRIPTION
If a user reloads the page, the navbar does not collapse or shrink until the user scrolls. This PR will auto-collapse the navbar if the user is currently more than 50 pixels down from the top of the page. 
