### PR TITLE
Added in scrollpage call from AnimateHeader update

### DIFF
--- a/js/cbpAnimatedHeader.js
+++ b/js/cbpAnimatedHeader.js
@@ -13,9 +13,10 @@ var cbpAnimatedHeader = (function() {
 	var docElem = document.documentElement,
 		header = document.querySelector( '.navbar-default' ),
 		didScroll = false,
-		changeHeaderOn = 300;
+		changeHeaderOn = 220;
 
 	function init() {
+		scrollPage();
 		window.addEventListener( 'scroll', function( event ) {
 			if( !didScroll ) {
 				didScroll = true;

--- a/js/cbpAnimatedHeader.min.js
+++ b/js/cbpAnimatedHeader.min.js
@@ -8,4 +8,4 @@
  * Copyright 2013, Codrops
  * http://www.codrops.com
  */
-var cbpAnimatedHeader=(function(){var b=document.documentElement,g=document.querySelector(".navbar-default"),e=false,a=300;function f(){window.addEventListener("scroll",function(h){if(!e){e=true;setTimeout(d,250)}},false)}function d(){var h=c();if(h>=a){classie.add(g,"navbar-shrink")}else{classie.remove(g,"navbar-shrink")}e=false}function c(){return window.pageYOffset||b.scrollTop}f()})();
+var cbpAnimatedHeader=(function(){var b=document.documentElement,g=document.querySelector(".navbar-default"),e=false,a=220;function f(){d();window.addEventListener("scroll",function(h){if(!e){e=true;setTimeout(d,250)}},false)}function d(){var h=c();if(h>=a){classie.add(g,"navbar-shrink")}else{classie.remove(g,"navbar-shrink")}e=false}function c(){return window.pageYOffset||b.scrollTop}f()})();


### PR DESCRIPTION
See #41. These PR reflects the changes proposed in the comments. scrollPage isn't always triggered and therefore the header doesn't shrink properly after reloading a page. Also, the transition point is too low on the page and the "Welcome to Our Studio" text ends up under the header before the header is shrunk. 
