### PR TITLE
Change license URL to match LICENSE file in repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Start Bootstrap",
   "license": {
     "type": "MIT",
-    "url": "https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE"
+    "url": "https://github.com/BlackrockDigital/startbootstrap-agency/blob/master/LICENSE"
   },
   "devDependencies": {
     "bootstrap": "^3.3.7",


### PR DESCRIPTION
The URL points to a Creative Commons License but the "type" and LICENSE file states MIT. Change URL to match the rest.
