### PR TITLE
 Dehardcode primary color shadow from Button (with 0.5 alpha)

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -74,7 +74,7 @@ section {
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem lighten($primary, 7.5%) !important;
+    box-shadow: 0 0 0 0.2rem rgba($primary,.5) !important;
   }
 }
 

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -74,7 +74,7 @@ section {
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba(254, 209, 55,.5) !important;
+    box-shadow: 0 0 0 0.2rem lighten($primary, 7.5%) !important;
   }
 }
 


### PR DESCRIPTION
The original primary color was hardcoded in the box shadow of .btn-primary (hover and active). _global.scss was modified so it uses the $primary color var for the shadow (with 0.5 alpha).