### PR TITLE
Dependency upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,48 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@compone/class": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@compone/class/-/class-1.1.1.tgz",
+            "integrity": "sha512-pbODcJi0TdyKQ/PTHSHLwO4h/r5EgMdkPQLdBSaZBUiBuWdGil+0PEhpfhAWDuFrwVPKiCHYQOfs8WyGe9ABWA==",
+            "dev": true
+        },
+        "@compone/define": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@compone/define/-/define-1.2.4.tgz",
+            "integrity": "sha512-w0ZDiYMIppvb1epoNY64pkEACwn9693cc7qM1ZSKWUVZczx5vlR4iZM7by129IYUdCq0SsbxQbbPZjnzj/0Qew==",
+            "dev": true,
+            "requires": {
+                "@compone/class": "1.1.1",
+                "@compone/event": "1.1.2"
+            }
+        },
+        "@compone/event": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@compone/event/-/event-1.1.2.tgz",
+            "integrity": "sha512-baJDnAr8pWefqfltNS33HieD+s23YO+w2/RD6lPxIEzlOuM1R5RT5vpUUTcrzn0Er3oj62PlfMUyS0SwnVw67Q==",
+            "dev": true,
+            "requires": {
+                "utilise": "2.3.7"
+            }
+        },
+        "@types/node": {
+            "version": "8.10.20",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz",
+            "integrity": "sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==",
+            "dev": true,
+            "optional": true
+        },
+        "JSONStream": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+            "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+            }
+        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -16,7 +58,7 @@
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.18",
+                "mime-types": "2.1.18",
                 "negotiator": "0.6.1"
             },
             "dependencies": {
@@ -32,9 +74,78 @@
                     "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "~1.33.0"
+                        "mime-db": "1.33.0"
                     }
                 }
+            }
+        },
+        "acorn": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+            "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+            "dev": true
+        },
+        "acorn-dynamic-import": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+            "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.7.1"
+            }
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "acorn-node": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.5.2.tgz",
+            "integrity": "sha512-krFKvw/d1F17AN3XZbybIUzEY4YEPNiGo05AfP3dBlfVKrMHETKpgjpuZkSF8qDNt9UkQcqj7am8yJLseklCMg==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.7.1",
+                "acorn-dynamic-import": "3.0.0",
+                "xtend": "4.0.1"
+            }
+        },
+        "acorn-object-spread": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz",
+            "integrity": "sha1-SOrQ9KjrFplaF6Dbn/xqyq2kumg=",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "acorn5-object-spread": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz",
+            "integrity": "sha1-1XWAge7ZcSGrC+R+Mcqu8qo5lpc=",
+            "dev": true,
+            "requires": {
+                "acorn": "5.7.1"
             }
         },
         "after": {
@@ -49,8 +160,8 @@
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "json-stable-stringify": "^1.0.1"
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
             }
         },
         "amdefine": {
@@ -65,7 +176,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "^0.1.0"
+                "ansi-wrap": "0.1.0"
             }
         },
         "ansi-gray": {
@@ -101,8 +212,8 @@
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
-                "micromatch": "^2.1.5",
-                "normalize-path": "^2.0.0"
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
             }
         },
         "aproba": {
@@ -110,6 +221,89 @@
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
+        },
+        "archiver": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+            "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+            "dev": true,
+            "requires": {
+                "archiver-utils": "1.3.0",
+                "async": "2.6.1",
+                "buffer-crc32": "0.2.13",
+                "glob": "7.1.2",
+                "lodash": "4.17.10",
+                "readable-stream": "2.3.3",
+                "tar-stream": "1.6.1",
+                "zip-stream": "1.2.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "4.17.10"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true
+                }
+            }
+        },
+        "archiver-utils": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+            "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lazystream": "1.0.0",
+                "lodash": "4.17.10",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.3"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true
+                }
+            }
         },
         "archy": {
             "version": "1.0.0",
@@ -123,8 +317,17 @@
             "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
             "dev": true,
             "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -133,7 +336,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.0.1"
+                "arr-flatten": "1.1.0"
             }
         },
         "arr-flatten": {
@@ -160,10 +363,34 @@
             "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
             "dev": true
         },
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+            "dev": true
+        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+            "dev": true
+        },
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+            "dev": true
+        },
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
             "dev": true
         },
         "array-slice": {
@@ -196,10 +423,53 @@
             "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
             "dev": true
         },
+        "asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
+            }
+        },
+        "assert": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+            "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
+            "dev": true,
+            "requires": {
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
         "assert-plus": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
             "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
         "assign-symbols": {
@@ -268,8 +538,8 @@
             "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.2.5",
-                "is-buffer": "^1.1.5"
+                "follow-redirects": "1.4.1",
+                "is-buffer": "1.1.6"
             }
         },
         "backo2": {
@@ -290,13 +560,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -305,7 +575,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -314,7 +584,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -323,7 +593,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -332,9 +602,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -357,6 +627,12 @@
             "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
             "dev": true
         },
+        "base64-js": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+            "dev": true
+        },
         "base64id": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
@@ -376,7 +652,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "beeper": {
@@ -394,11 +670,70 @@
                 "callsite": "1.0.0"
             }
         },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "buffers": "0.1.1",
+                "chainsaw": "0.1.0"
+            }
+        },
         "binary-extensions": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
             "dev": true
+        },
+        "bl": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.6",
+                "safe-buffer": "5.1.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
         },
         "blob": {
             "version": "0.0.4",
@@ -412,7 +747,39 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
+            }
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "body-parser": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "dev": true,
+            "requires": {
+                "bytes": "3.0.0",
+                "content-type": "1.0.4",
+                "debug": "2.6.9",
+                "depd": "1.1.1",
+                "http-errors": "1.6.2",
+                "iconv-lite": "0.4.19",
+                "on-finished": "2.3.0",
+                "qs": "6.5.1",
+                "raw-body": "2.3.2",
+                "type-is": "1.6.16"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "dev": true
+                }
             }
         },
         "boom": {
@@ -421,7 +788,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "bootstrap": {
@@ -435,7 +802,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -445,10 +812,71 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
             }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-icons": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/browser-icons/-/browser-icons-0.0.1.tgz",
+            "integrity": "sha1-iI5fEHY2A3RfpxgOTNjbCitlSOw=",
+            "dev": true,
+            "requires": {
+                "icon-android": "0.0.1",
+                "icon-chrome": "0.0.1",
+                "icon-firefox": "0.0.1",
+                "icon-ie": "0.0.1",
+                "icon-ios": "0.0.1",
+                "icon-linux": "0.0.1",
+                "icon-opera": "0.0.1",
+                "icon-osx": "0.0.1",
+                "icon-safari": "0.0.1",
+                "icon-windows": "0.0.1"
+            }
+        },
+        "browser-pack": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+            "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.3",
+                "combine-source-map": "0.8.0",
+                "defined": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "through2": "2.0.3",
+                "umd": "3.0.3"
+            }
+        },
+        "browser-resolve": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
         },
         "browser-sync": {
             "version": "2.24.3",
@@ -456,16 +884,16 @@
             "integrity": "sha512-X+6VIrakzQDF7HHskSXhBqLxaO2Jy87HShL8zeGzfwvBhWqza0r9ISGQBF664RVu6vlUsvQMNo0cWfZNJs7sWQ==",
             "dev": true,
             "requires": {
-                "browser-sync-ui": "v1.0.1",
+                "browser-sync-ui": "1.0.1",
                 "bs-recipes": "1.3.4",
                 "chokidar": "1.7.0",
                 "connect": "3.5.0",
-                "connect-history-api-fallback": "^1.5.0",
-                "dev-ip": "^1.0.1",
+                "connect-history-api-fallback": "1.5.0",
+                "dev-ip": "1.0.1",
                 "easy-extender": "2.3.2",
                 "eazy-logger": "3.0.2",
-                "etag": "^1.8.1",
-                "fresh": "^0.5.2",
+                "etag": "1.8.1",
+                "fresh": "0.5.2",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
                 "immutable": "3.8.2",
@@ -474,7 +902,7 @@
                 "opn": "4.0.2",
                 "portscanner": "2.1.1",
                 "qs": "6.2.3",
-                "raw-body": "^2.3.2",
+                "raw-body": "2.3.2",
                 "resp-modifier": "6.0.2",
                 "rx": "4.1.0",
                 "serve-index": "1.8.0",
@@ -492,11 +920,172 @@
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "^1.1.0",
-                "immutable": "^3.7.6",
+                "connect-history-api-fallback": "1.5.0",
+                "immutable": "3.8.2",
                 "server-destroy": "1.0.1",
                 "socket.io-client": "2.0.4",
-                "stream-throttle": "^0.1.3"
+                "stream-throttle": "0.1.3"
+            }
+        },
+        "browserify": {
+            "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-12.0.2.tgz",
+            "integrity": "sha1-V/IeXm4wj/WYfE2v1EhAsrmPehk=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.3",
+                "assert": "1.3.0",
+                "browser-pack": "6.1.0",
+                "browser-resolve": "1.11.3",
+                "browserify-zlib": "0.1.4",
+                "buffer": "3.6.0",
+                "concat-stream": "1.5.2",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "defined": "1.0.0",
+                "deps-sort": "2.0.0",
+                "domain-browser": "1.1.7",
+                "duplexer2": "0.1.4",
+                "events": "1.1.1",
+                "glob": "5.0.15",
+                "has": "1.0.3",
+                "htmlescape": "1.1.1",
+                "https-browserify": "0.0.1",
+                "inherits": "2.0.3",
+                "insert-module-globals": "7.2.0",
+                "isarray": "0.0.1",
+                "labeled-stream-splicer": "2.0.1",
+                "module-deps": "4.1.1",
+                "os-browserify": "0.1.2",
+                "parents": "1.0.1",
+                "path-browserify": "0.0.1",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "read-only-stream": "2.0.0",
+                "readable-stream": "2.3.3",
+                "resolve": "1.7.1",
+                "shasum": "1.0.2",
+                "shell-quote": "1.6.1",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.3",
+                "string_decoder": "0.10.31",
+                "subarg": "1.0.0",
+                "syntax-error": "1.4.0",
+                "through2": "2.0.3",
+                "timers-browserify": "1.4.2",
+                "tty-browserify": "0.0.1",
+                "url": "0.11.0",
+                "util": "0.10.4",
+                "vm-browserify": "0.0.4",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "duplexer2": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+                    "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
+                },
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.1",
+                "evp_bytestokey": "1.0.3"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+            "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.1"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+            "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+            "dev": true,
+            "requires": {
+                "pako": "0.2.9"
             }
         },
         "bs-recipes": {
@@ -505,10 +1094,106 @@
             "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
             "dev": true
         },
+        "buble": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/buble/-/buble-0.16.0.tgz",
+            "integrity": "sha512-Eb5vt1+IvXXPyYD1IIQIuaBwIuJOSWQ2kXzULlg5I83aLGF2qzcjRU2joYusnWFgAenvJ9xTOMvZvT0bb8BLbg==",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0",
+                "acorn-jsx": "3.0.1",
+                "acorn-object-spread": "1.0.0",
+                "chalk": "1.1.3",
+                "magic-string": "0.14.0",
+                "minimist": "1.2.0",
+                "os-homedir": "1.0.2",
+                "vlq": "0.2.3"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "buffer": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+            "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+            "dev": true,
+            "requires": {
+                "base64-js": "0.0.8",
+                "ieee754": "1.1.12",
+                "isarray": "1.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dev": true,
+            "requires": {
+                "buffer-alloc-unsafe": "1.1.0",
+                "buffer-fill": "1.0.0"
+            }
+        },
+        "buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-fill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+            "dev": true,
+            "optional": true
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
             "dev": true
         },
         "bytes": {
@@ -523,15 +1208,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -541,6 +1226,12 @@
                     "dev": true
                 }
             }
+        },
+        "cached-path-relative": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+            "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+            "dev": true
         },
         "callsite": {
             "version": "1.0.0",
@@ -560,8 +1251,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
             },
             "dependencies": {
                 "camelcase": {
@@ -578,18 +1269,48 @@
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
+        "chai": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+            "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.1.0",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.8"
+            }
+        },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "traverse": "0.3.9"
+            }
+        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
             }
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
         },
         "chokidar": {
             "version": "1.7.0",
@@ -597,15 +1318,25 @@
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "fsevents": "1.2.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
             }
         },
         "class-utils": {
@@ -614,10 +1345,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -626,7 +1357,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "isobject": {
@@ -643,7 +1374,7 @@
             "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.x"
+                "source-map": "0.5.7"
             }
         },
         "cliui": {
@@ -652,9 +1383,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
             }
         },
         "clone": {
@@ -687,8 +1418,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -697,7 +1428,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -712,13 +1443,31 @@
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "dev": true
         },
+        "colors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+            "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
+            "dev": true
+        },
+        "combine-source-map": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "1.1.3",
+                "inline-source-map": "0.6.2",
+                "lodash.memoize": "3.0.4",
+                "source-map": "0.5.7"
+            }
+        },
         "combined-stream": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -745,11 +1494,94 @@
             "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
+        "compress-commons": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+            "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "crc32-stream": "2.0.0",
+                "normalize-path": "2.1.1",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "compressible": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
+            "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.34.0"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.34.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
+                    "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o=",
+                    "dev": true
+                }
+            }
+        },
+        "compression": {
+            "version": "1.7.2",
+            "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+            "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+            "dev": true,
+            "requires": {
+                "accepts": "1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "2.0.14",
+                "debug": "2.6.9",
+                "on-headers": "1.0.1",
+                "safe-buffer": "5.1.1",
+                "vary": "1.1.2"
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "concat-stream": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+            "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6",
+                "typedarray": "0.0.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
         },
         "concat-with-sourcemaps": {
             "version": "1.0.5",
@@ -757,7 +1589,7 @@
             "integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
             "dev": true,
             "requires": {
-                "source-map": "^0.6.1"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -774,9 +1606,9 @@
             "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
             "dev": true,
             "requires": {
-                "debug": "~2.2.0",
+                "debug": "2.2.0",
                 "finalhandler": "0.5.0",
-                "parseurl": "~1.3.1",
+                "parseurl": "1.3.2",
                 "utils-merge": "1.0.0"
             },
             "dependencies": {
@@ -803,16 +1635,65 @@
             "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
             "dev": true
         },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "0.1.4"
+            }
+        },
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+            "dev": true
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+            "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+            "dev": true
+        },
         "cookie": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
             "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+            "dev": true
+        },
+        "cookie-parser": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+            "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+            "dev": true,
+            "requires": {
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6"
+            }
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
         "copy-descriptor": {
@@ -827,14 +1708,67 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
+        "crc": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+            "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms=",
+            "dev": true
+        },
+        "crc32-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+            "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+            "dev": true,
+            "requires": {
+                "crc": "3.4.4",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "create-ecdh": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "md5.js": "1.3.4",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.11"
+            }
+        },
         "cross-spawn": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
             "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.2",
+                "which": "1.3.0"
             },
             "dependencies": {
                 "lru-cache": {
@@ -843,11 +1777,17 @@
                     "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 }
             }
+        },
+        "cryonic": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cryonic/-/cryonic-1.0.0.tgz",
+            "integrity": "sha512-8wqWtdI+7IQVYCDS40H/H267zb2Lwn08Q7HT0hIqHNMkRPQdV355dPRu/hV02k2sBtZJ+KEnRVtaZWzT3hPVmQ==",
+            "dev": true
         },
         "cryptiles": {
             "version": "2.0.5",
@@ -855,7 +1795,26 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.x.x"
+                "boom": "2.10.1"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.16",
+                "public-encrypt": "4.0.2",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
             }
         },
         "currently-unhandled": {
@@ -864,7 +1823,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "^1.0.1"
+                "array-find-index": "1.0.2"
             }
         },
         "dashdash": {
@@ -873,7 +1832,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -883,6 +1842,12 @@
                     "dev": true
                 }
             }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
         },
         "dateformat": {
             "version": "2.2.0",
@@ -911,13 +1876,67 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
+        "decompress-zip": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.1.tgz",
+            "integrity": "sha512-pNGzi0RIpLA/CqrMQoSuh/1+YiVGJSEhQeibgoZQEdPFQOhO5pvqim3sp1qMvio3+mkonUQ1Akjdw8RgvV/RsA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "binary": "0.3.0",
+                "graceful-fs": "4.1.11",
+                "mkpath": "0.1.0",
+                "nopt": "3.0.6",
+                "q": "1.5.1",
+                "readable-stream": "1.1.14",
+                "touch": "0.0.3"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true,
+                    "optional": true
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
         "defaults": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "^1.0.2"
+                "clone": "1.0.4"
             }
         },
         "define-property": {
@@ -926,8 +1945,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -936,7 +1955,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -945,7 +1964,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -954,9 +1973,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -972,6 +1991,12 @@
                     "dev": true
                 }
             }
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -997,6 +2022,28 @@
             "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
             "dev": true
         },
+        "deps-sort": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+            "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.3",
+                "shasum": "1.0.2",
+                "subarg": "1.0.0",
+                "through2": "2.0.3"
+            }
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
+            }
+        },
         "destroy": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1009,10 +2056,49 @@
             "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
             "dev": true
         },
+        "detective": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+            "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.7.1",
+                "defined": "1.0.0"
+            }
+        },
         "dev-ip": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
             "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
+            }
+        },
+        "djbx": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/djbx/-/djbx-1.0.3.tgz",
+            "integrity": "sha512-Y8ph/85fEChtSgSgw1asP4cGLNLxlbnDBnQMpX8+MOpaiYyOn8assnSpIrwHuoGZV/sE1DUbKh9aeKlWZdHKEg==",
+            "dev": true
+        },
+        "domain-browser": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+            "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
             "dev": true
         },
         "duplexer2": {
@@ -1021,7 +2107,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "~1.1.9"
+                "readable-stream": "1.1.14"
             },
             "dependencies": {
                 "isarray": {
@@ -1036,10 +2122,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -1056,7 +2142,7 @@
             "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
             "dev": true,
             "requires": {
-                "lodash": "^3.10.1"
+                "lodash": "3.10.1"
             }
         },
         "eazy-logger": {
@@ -1065,7 +2151,7 @@
             "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
             "dev": true,
             "requires": {
-                "tfunk": "^3.0.1"
+                "tfunk": "3.1.0"
             }
         },
         "ecc-jsbn": {
@@ -1075,7 +2161,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "ee-first": {
@@ -1083,6 +2169,21 @@
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
             "dev": true
+        },
+        "elliptic": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.4",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -1096,7 +2197,7 @@
             "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
             "dev": true,
             "requires": {
-                "once": "~1.3.0"
+                "once": "1.3.3"
             }
         },
         "engine.io": {
@@ -1105,13 +2206,13 @@
             "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.4",
+                "accepts": "1.3.5",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.0",
-                "uws": "~9.14.0",
-                "ws": "~3.3.1"
+                "debug": "3.1.0",
+                "engine.io-parser": "2.1.2",
+                "uws": "9.14.0",
+                "ws": "3.3.3"
             },
             "dependencies": {
                 "debug": {
@@ -1133,14 +2234,14 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.1",
+                "debug": "3.1.0",
+                "engine.io-parser": "2.1.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "~3.3.1",
-                "xmlhttprequest-ssl": "~1.5.4",
+                "ws": "3.3.3",
+                "xmlhttprequest-ssl": "1.5.5",
                 "yeast": "0.1.2"
             },
             "dependencies": {
@@ -1162,10 +2263,10 @@
             "dev": true,
             "requires": {
                 "after": "0.8.2",
-                "arraybuffer.slice": "~0.0.7",
+                "arraybuffer.slice": "0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.4",
-                "has-binary2": "~1.0.2"
+                "has-binary2": "1.0.2"
             }
         },
         "error-ex": {
@@ -1174,7 +2275,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "escape-html": {
@@ -1189,6 +2290,12 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "dev": true
+        },
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1201,13 +2308,29 @@
             "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
             "dev": true
         },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
+            }
+        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
             }
         },
         "expand-range": {
@@ -1216,7 +2339,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.3"
             }
         },
         "expand-tilde": {
@@ -1225,7 +2348,117 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
+            }
+        },
+        "express": {
+            "version": "4.16.3",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+            "dev": true,
+            "requires": {
+                "accepts": "1.3.5",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.18.2",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.4",
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
+                "finalhandler": "1.1.1",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "2.0.3",
+                "qs": "6.5.1",
+                "range-parser": "1.2.0",
+                "safe-buffer": "5.1.1",
+                "send": "0.16.2",
+                "serve-static": "1.13.2",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
+                "utils-merge": "1.0.1",
+                "vary": "1.1.2"
+            },
+            "dependencies": {
+                "depd": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+                    "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+                    "dev": true
+                },
+                "finalhandler": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+                    "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.9",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.4.0",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                    "dev": true
+                },
+                "utils-merge": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+                    "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+                    "dev": true
+                }
+            }
+        },
+        "express-session": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
+            "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
+            "dev": true,
+            "requires": {
+                "cookie": "0.3.1",
+                "cookie-signature": "1.0.6",
+                "crc": "3.4.4",
+                "debug": "2.6.9",
+                "depd": "1.1.1",
+                "on-headers": "1.0.1",
+                "parseurl": "1.3.2",
+                "uid-safe": "2.1.5",
+                "utils-merge": "1.0.1"
+            },
+            "dependencies": {
+                "utils-merge": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+                    "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -1240,8 +2473,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1250,7 +2483,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -1261,7 +2494,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "extsprintf": {
@@ -1276,10 +2509,22 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "time-stamp": "^1.0.0"
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
+                "time-stamp": "1.1.0"
             }
+        },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
         },
         "filename-regex": {
             "version": "2.0.1",
@@ -1293,11 +2538,11 @@
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^1.1.3",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
             }
         },
         "finalhandler": {
@@ -1306,11 +2551,11 @@
             "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
             "dev": true,
             "requires": {
-                "debug": "~2.2.0",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "statuses": "~1.3.0",
-                "unpipe": "~1.0.0"
+                "debug": "2.2.0",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "statuses": "1.3.1",
+                "unpipe": "1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -1336,14 +2581,20 @@
             "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
             "dev": true
         },
+        "find-package-json": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.1.0.tgz",
+            "integrity": "sha512-ldihxiIFpewACALK0tUByf3GmOaTBjI5OcvwJ3mExgERUZBsSOBV8QM6vVb0/ZqylpzY6Od6SsP8bjFv7fKiTw==",
+            "dev": true
+        },
         "find-up": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "findup-sync": {
@@ -1352,10 +2603,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "detect-file": "1.0.0",
+                "is-glob": "3.1.0",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1376,16 +2627,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1394,7 +2645,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -1405,13 +2656,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1420,7 +2671,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -1429,7 +2680,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -1438,7 +2689,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -1447,7 +2698,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -1458,7 +2709,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -1467,7 +2718,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -1478,9 +2729,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
                             }
                         },
                         "kind-of": {
@@ -1497,14 +2748,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1513,7 +2764,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -1522,7 +2773,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -1533,10 +2784,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1545,7 +2796,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -1556,7 +2807,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1565,7 +2816,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1574,9 +2825,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -1591,7 +2842,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "is-number": {
@@ -1600,7 +2851,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1609,7 +2860,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -1632,19 +2883,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.9",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 }
             }
@@ -1655,11 +2906,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "is-plain-object": "^2.0.3",
-                "object.defaults": "^1.1.0",
-                "object.pick": "^1.2.0",
-                "parse-filepath": "^1.0.1"
+                "expand-tilde": "2.0.2",
+                "is-plain-object": "2.0.4",
+                "object.defaults": "1.1.0",
+                "object.pick": "1.3.0",
+                "parse-filepath": "1.0.2"
             }
         },
         "first-chunk-stream": {
@@ -1680,7 +2931,7 @@
             "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0"
+                "debug": "3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1711,7 +2962,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -1726,10 +2977,16 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
             }
+        },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+            "dev": true
         },
         "fragment-cache": {
             "version": "0.2.1",
@@ -1737,7 +2994,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fresh": {
@@ -1746,15 +3003,21 @@
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
             "dev": true
         },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
+        },
         "fs-extra": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
             "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^3.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "4.1.11",
+                "jsonfile": "3.0.1",
+                "universalify": "0.1.1"
             }
         },
         "fs.realpath": {
@@ -1770,8 +3033,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.9.0"
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.9.1"
             },
             "dependencies": {
                 "abbrev": {
@@ -1797,8 +3060,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "balanced-match": {
@@ -1811,7 +3074,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1875,7 +3138,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
@@ -1890,14 +3153,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
                     }
                 },
                 "glob": {
@@ -1906,12 +3169,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-unicode": {
@@ -1926,7 +3189,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "ignore-walk": {
@@ -1935,7 +3198,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
@@ -1944,8 +3207,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -1964,7 +3227,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -1978,7 +3241,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -1991,8 +3254,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "minizlib": {
@@ -2001,7 +3264,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "mkdirp": {
@@ -2024,9 +3287,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2035,16 +3298,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.6",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
                     }
                 },
                 "nopt": {
@@ -2053,8 +3316,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "npm-bundled": {
@@ -2069,8 +3332,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
@@ -2079,10 +3342,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2101,7 +3364,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
@@ -2122,8 +3385,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -2144,10 +3407,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "~0.4.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2164,13 +3427,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
@@ -2179,7 +3442,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
@@ -2222,9 +3485,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2233,7 +3496,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 },
                 "strip-ansi": {
@@ -2241,7 +3504,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
@@ -2256,13 +3519,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2277,7 +3540,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2298,11 +3561,17 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -2310,14 +3579,14 @@
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
             }
         },
         "gaze": {
@@ -2326,7 +3595,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "~0.1.0"
+                "globule": "0.1.0"
             }
         },
         "generate-function": {
@@ -2341,13 +3610,25 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "^1.0.0"
+                "is-property": "1.0.2"
             }
+        },
+        "get-assigned-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+            "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
             "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
         "get-stdin": {
@@ -2368,7 +3649,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2385,10 +3666,10 @@
             "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
             "dev": true,
             "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "2.0.10",
+                "once": "1.3.3"
             },
             "dependencies": {
                 "minimatch": {
@@ -2397,7 +3678,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.0.0"
+                        "brace-expansion": "1.1.8"
                     }
                 }
             }
@@ -2408,8 +3689,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "glob-parent": {
@@ -2418,7 +3699,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "^2.0.0"
+                "is-glob": "2.0.1"
             }
         },
         "glob-stream": {
@@ -2427,12 +3708,12 @@
             "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
             "dev": true,
             "requires": {
-                "glob": "^4.3.1",
-                "glob2base": "^0.0.12",
-                "minimatch": "^2.0.1",
-                "ordered-read-streams": "^0.1.0",
-                "through2": "^0.6.1",
-                "unique-stream": "^1.0.0"
+                "glob": "4.5.3",
+                "glob2base": "0.0.12",
+                "minimatch": "2.0.10",
+                "ordered-read-streams": "0.1.0",
+                "through2": "0.6.5",
+                "unique-stream": "1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -2447,7 +3728,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.0.0"
+                        "brace-expansion": "1.1.8"
                     }
                 },
                 "readable-stream": {
@@ -2456,10 +3737,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -2474,8 +3755,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -2486,7 +3767,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "^0.5.1"
+                "gaze": "0.5.2"
             }
         },
         "glob2base": {
@@ -2495,7 +3776,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "^0.1.1"
+                "find-index": "0.1.1"
             }
         },
         "global-modules": {
@@ -2504,9 +3785,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
+                "global-prefix": "1.0.2",
+                "is-windows": "1.0.2",
+                "resolve-dir": "1.0.1"
             }
         },
         "global-prefix": {
@@ -2515,11 +3796,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
+                "expand-tilde": "2.0.2",
+                "homedir-polyfill": "1.0.1",
+                "ini": "1.3.5",
+                "is-windows": "1.0.2",
+                "which": "1.3.0"
             }
         },
         "globule": {
@@ -2528,9 +3809,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "~3.1.21",
-                "lodash": "~1.0.1",
-                "minimatch": "~0.2.11"
+                "glob": "3.1.21",
+                "lodash": "1.0.2",
+                "minimatch": "0.2.14"
             },
             "dependencies": {
                 "glob": {
@@ -2539,9 +3820,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "~1.2.0",
-                        "inherits": "1",
-                        "minimatch": "~0.2.11"
+                        "graceful-fs": "1.2.3",
+                        "inherits": "1.0.2",
+                        "minimatch": "0.2.14"
                     }
                 },
                 "graceful-fs": {
@@ -2568,8 +3849,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
                     }
                 }
             }
@@ -2580,7 +3861,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.0"
             }
         },
         "graceful-fs": {
@@ -2589,25 +3870,31 @@
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
             "dev": true
         },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
+        },
         "gulp": {
             "version": "3.9.1",
             "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "chalk": "^1.0.0",
-                "deprecated": "^0.0.1",
-                "gulp-util": "^3.0.0",
-                "interpret": "^1.0.0",
-                "liftoff": "^2.1.0",
-                "minimist": "^1.1.0",
-                "orchestrator": "^0.3.0",
-                "pretty-hrtime": "^1.0.0",
-                "semver": "^4.1.0",
-                "tildify": "^1.0.0",
-                "v8flags": "^2.0.2",
-                "vinyl-fs": "^0.3.0"
+                "archy": "1.0.0",
+                "chalk": "1.1.3",
+                "deprecated": "0.0.1",
+                "gulp-util": "3.0.8",
+                "interpret": "1.1.0",
+                "liftoff": "2.5.0",
+                "minimist": "1.2.0",
+                "orchestrator": "0.3.8",
+                "pretty-hrtime": "1.0.3",
+                "semver": "4.3.6",
+                "tildify": "1.2.0",
+                "v8flags": "2.1.1",
+                "vinyl-fs": "0.3.14"
             },
             "dependencies": {
                 "semver": {
@@ -2636,9 +3923,9 @@
             "integrity": "sha512-7bOIiHvM1GUHIG3LRH+UIanOxyjSys0FbzzgUBlV2cZIIZihEW+KKKKm0ejUBNGvRdhISEFFr6HlptXoa28gtQ==",
             "dev": true,
             "requires": {
-                "concat-with-sourcemaps": "*",
-                "lodash.template": "^4.4.0",
-                "through2": "^2.0.0"
+                "concat-with-sourcemaps": "1.0.5",
+                "lodash.template": "4.4.0",
+                "through2": "2.0.3"
             },
             "dependencies": {
                 "lodash.template": {
@@ -2647,8 +3934,8 @@
                     "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "~3.0.0",
-                        "lodash.templatesettings": "^4.0.0"
+                        "lodash._reinterpolate": "3.0.0",
+                        "lodash.templatesettings": "4.1.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -2657,15 +3944,15 @@
                     "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "~3.0.0"
+                        "lodash._reinterpolate": "3.0.0"
                     }
                 }
             }
         },
         "gulp-rename": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
-            "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.3.0.tgz",
+            "integrity": "sha512-nEuZB7/9i0IZ8AXORTizl2QLP9tcC9uWc/s329zElBLJw1CfOhmMXBxwVlCRKjDyrWuhVP0uBKl61KeQ32TiCg==",
             "dev": true
         },
         "gulp-sass": {
@@ -2674,14 +3961,14 @@
             "integrity": "sha512-OMQEgWNggpog8Tc5v1MuI6eo+5iiPkVeLL76iBhDoEEScLUPfZlpvzmgTnLkpcqdrNodZxpz5qcv6mS2rulk3g==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
-                "lodash.clonedeep": "^4.3.2",
-                "node-sass": "^4.8.3",
-                "plugin-error": "^1.0.1",
-                "replace-ext": "^1.0.0",
-                "strip-ansi": "^4.0.0",
-                "through2": "^2.0.0",
-                "vinyl-sourcemaps-apply": "^0.2.0"
+                "chalk": "2.3.2",
+                "lodash.clonedeep": "4.5.0",
+                "node-sass": "4.8.3",
+                "plugin-error": "1.0.1",
+                "replace-ext": "1.0.0",
+                "strip-ansi": "4.0.0",
+                "through2": "2.0.3",
+                "vinyl-sourcemaps-apply": "0.2.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2696,7 +3983,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -2705,9 +3992,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.3.0"
                     }
                 },
                 "replace-ext": {
@@ -2722,7 +4009,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "supports-color": {
@@ -2731,7 +4018,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -2742,13 +4029,13 @@
             "integrity": "sha1-DfAzHXKg0wLj434QlIXd3zPG0co=",
             "dev": true,
             "requires": {
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash": "^4.13.1",
-                "make-error-cause": "^1.1.1",
-                "through2": "^2.0.0",
-                "uglify-js": "^3.0.5",
-                "vinyl-sourcemaps-apply": "^0.2.0"
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash": "4.17.4",
+                "make-error-cause": "1.2.2",
+                "through2": "2.0.3",
+                "uglify-js": "3.3.9",
+                "vinyl-sourcemaps-apply": "0.2.1"
             },
             "dependencies": {
                 "lodash": {
@@ -2765,24 +4052,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.2.0",
+                "fancy-log": "1.3.2",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
             },
             "dependencies": {
                 "object-assign": {
@@ -2799,7 +4086,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "^1.0.0"
+                "glogg": "1.0.1"
             }
         },
         "har-schema": {
@@ -2814,8 +4101,17 @@
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "dev": true,
             "requires": {
-                "ajv": "^4.9.1",
-                "har-schema": "^1.0.5"
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -2824,7 +4120,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-binary2": {
@@ -2854,7 +4150,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.0"
             }
         },
         "has-unicode": {
@@ -2869,9 +4165,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -2888,8 +4184,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2898,7 +4194,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2907,7 +4203,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -2918,9 +4214,29 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
+            }
+        },
+        "hash-base": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+            "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "hawk": {
@@ -2929,10 +4245,27 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+            }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "1.1.4",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoek": {
@@ -2947,13 +4280,19 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "^1.0.0"
+                "parse-passwd": "1.0.0"
             }
         },
         "hosted-git-info": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+            "dev": true
+        },
+        "htmlescape": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
             "dev": true
         },
         "http-errors": {
@@ -2965,7 +4304,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
+                "statuses": "1.3.1"
             }
         },
         "http-proxy": {
@@ -2974,8 +4313,8 @@
             "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.x.x",
-                "requires-port": "1.x.x"
+                "eventemitter3": "1.2.0",
+                "requires-port": "1.0.0"
             }
         },
         "http-signature": {
@@ -2984,15 +4323,87 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "^0.2.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
             }
+        },
+        "https-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+            "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+            "dev": true
+        },
+        "icon-android": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-android/-/icon-android-0.0.1.tgz",
+            "integrity": "sha1-UGtOpgCQp5LsRe5oWps2GSqmysg=",
+            "dev": true
+        },
+        "icon-chrome": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-chrome/-/icon-chrome-0.0.1.tgz",
+            "integrity": "sha1-pyTLBEyeuqXglHIYgVJnlLcbPaQ=",
+            "dev": true
+        },
+        "icon-firefox": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-firefox/-/icon-firefox-0.0.1.tgz",
+            "integrity": "sha1-a5GneSa8kQcP+DlwVu/0t6oV+iQ=",
+            "dev": true
+        },
+        "icon-ie": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-ie/-/icon-ie-0.0.1.tgz",
+            "integrity": "sha1-At7nWwtd4+dd6+FoPsNq9tSpu9k=",
+            "dev": true
+        },
+        "icon-ios": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-ios/-/icon-ios-0.0.1.tgz",
+            "integrity": "sha1-Fsq8YSVb1Mo8Z5owxUWSJGoHP3k=",
+            "dev": true
+        },
+        "icon-linux": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-linux/-/icon-linux-0.0.1.tgz",
+            "integrity": "sha1-Ih7OHpsOJE/T7uj7weHSnNTbtrA=",
+            "dev": true
+        },
+        "icon-opera": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-opera/-/icon-opera-0.0.1.tgz",
+            "integrity": "sha1-zlpxU25lvvZpwPY4fYvMBxlNZA8=",
+            "dev": true
+        },
+        "icon-osx": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-osx/-/icon-osx-0.0.1.tgz",
+            "integrity": "sha1-Gpf94GZqyB+eW+/Kun8Z/UvVVtA=",
+            "dev": true
+        },
+        "icon-safari": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-safari/-/icon-safari-0.0.1.tgz",
+            "integrity": "sha1-h0r8wJPej3Dsxbalws2DifqlUiw=",
+            "dev": true
+        },
+        "icon-windows": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/icon-windows/-/icon-windows-0.0.1.tgz",
+            "integrity": "sha1-q+Rj9Q8Q1t/DvqLV/9Shs1C1f80=",
+            "dev": true
         },
         "iconv-lite": {
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
             "dev": true
         },
         "immutable": {
@@ -3013,7 +4424,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "indexof": {
@@ -3028,8 +4439,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -3044,6 +4455,47 @@
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
+        "inline-source-map": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7"
+            }
+        },
+        "insert-module-globals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+            "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.3",
+                "acorn-node": "1.5.2",
+                "combine-source-map": "0.8.0",
+                "concat-stream": "1.6.2",
+                "is-buffer": "1.1.6",
+                "path-is-absolute": "1.0.1",
+                "process": "0.11.10",
+                "through2": "2.0.3",
+                "undeclared-identifiers": "1.1.2",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "1.1.0",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.3",
+                        "typedarray": "0.0.6"
+                    }
+                }
+            }
+        },
         "interpret": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -3056,14 +4508,20 @@
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
             "dev": true
         },
+        "ipaddr.js": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+            "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+            "dev": true
+        },
         "is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.2"
             }
         },
         "is-accessor-descriptor": {
@@ -3072,7 +4530,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-arrayish": {
@@ -3087,7 +4545,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.11.0"
             }
         },
         "is-buffer": {
@@ -3102,7 +4560,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-data-descriptor": {
@@ -3111,7 +4569,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-descriptor": {
@@ -3120,9 +4578,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3145,7 +4603,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -3166,7 +4624,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-fullwidth-code-point": {
@@ -3175,7 +4633,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-glob": {
@@ -3184,7 +4642,7 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "is-my-ip-valid": {
@@ -3199,11 +4657,11 @@
             "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
             "dev": true,
             "requires": {
-                "generate-function": "^2.0.0",
-                "generate-object-property": "^1.1.0",
-                "is-my-ip-valid": "^1.0.0",
-                "jsonpointer": "^4.0.0",
-                "xtend": "^4.0.0"
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "is-my-ip-valid": "1.0.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
             }
         },
         "is-number": {
@@ -3212,7 +4670,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-number-like": {
@@ -3221,7 +4679,7 @@
             "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
             "dev": true,
             "requires": {
-                "lodash.isfinite": "^3.3.2"
+                "lodash.isfinite": "3.3.2"
             }
         },
         "is-odd": {
@@ -3230,7 +4688,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0"
+                "is-number": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -3247,7 +4705,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -3282,7 +4740,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "^1.0.0"
+                "is-unc-path": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -3297,7 +4755,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "^0.1.2"
+                "unc-path-regex": "0.1.2"
             }
         },
         "is-utf8": {
@@ -3363,6 +4821,16 @@
             "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
             "dev": true
         },
+        "js-yaml": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
+            }
+        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3376,13 +4844,19 @@
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
             "dev": true
         },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
         "json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -3397,13 +4871,19 @@
             "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "4.1.11"
             }
         },
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
             "dev": true
         },
         "jsonpointer": {
@@ -3438,7 +4918,35 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
+            }
+        },
+        "labeled-stream-splicer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+            "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "isarray": "2.0.4",
+                "stream-splicer": "2.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
+                    "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
+                    "dev": true
+                }
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
             }
         },
         "lcid": {
@@ -3447,7 +4955,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "liftoff": {
@@ -3456,14 +4964,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
-                "fined": "^1.0.1",
-                "flagged-respawn": "^1.0.0",
-                "is-plain-object": "^2.0.4",
-                "object.map": "^1.0.0",
-                "rechoir": "^0.6.2",
-                "resolve": "^1.1.7"
+                "extend": "3.0.1",
+                "findup-sync": "2.0.0",
+                "fined": "1.1.0",
+                "flagged-respawn": "1.0.0",
+                "is-plain-object": "2.0.4",
+                "object.map": "1.0.1",
+                "rechoir": "0.6.2",
+                "resolve": "1.7.1"
             }
         },
         "limiter": {
@@ -3478,11 +4986,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
             }
         },
         "localtunnel": {
@@ -3512,19 +5020,19 @@
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^4.2.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "4.2.1"
                     }
                 }
             }
@@ -3607,7 +5115,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "^3.0.0"
+                "lodash._root": "3.0.1"
             }
         },
         "lodash.isarguments": {
@@ -3634,10 +5142,16 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
             }
+        },
+        "lodash.memoize": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+            "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+            "dev": true
         },
         "lodash.mergewith": {
             "version": "4.6.1",
@@ -3657,15 +5171,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
             }
         },
         "lodash.templatesettings": {
@@ -3674,8 +5188,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
             }
         },
         "loud-rejection": {
@@ -3684,8 +5198,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
             }
         },
         "lru-cache": {
@@ -3693,6 +5207,21 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
             "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
             "dev": true
+        },
+        "lru_map": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+            "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=",
+            "dev": true
+        },
+        "magic-string": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.14.0.tgz",
+            "integrity": "sha1-VyJK7xcByu7Sc7F6OalW5ysXJGI=",
+            "dev": true,
+            "requires": {
+                "vlq": "0.2.3"
+            }
         },
         "make-error": {
             "version": "1.3.2",
@@ -3706,7 +5235,7 @@
             "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
             "dev": true,
             "requires": {
-                "make-error": "^1.2.0"
+                "make-error": "1.3.2"
             }
         },
         "make-iterator": {
@@ -3715,7 +5244,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3744,8 +5273,24 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "dev": true,
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
+            }
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
         },
         "meow": {
             "version": "3.7.0",
@@ -3753,17 +5298,29 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.4.0",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
             }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true
         },
         "micromatch": {
             "version": "2.3.11",
@@ -3771,19 +5328,29 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime": {
@@ -3804,8 +5371,20 @@
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "dev": true,
             "requires": {
-                "mime-db": "~1.30.0"
+                "mime-db": "1.30.0"
             }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -3813,7 +5392,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
             }
         },
         "minimist": {
@@ -3828,8 +5407,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3838,7 +5417,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -3857,6 +5436,106 @@
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "dev": true
+                }
+            }
+        },
+        "mkpath": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+            "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+            "dev": true,
+            "optional": true
+        },
+        "mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.15.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "module-deps": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+            "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.3",
+                "browser-resolve": "1.11.3",
+                "cached-path-relative": "1.0.1",
+                "concat-stream": "1.5.2",
+                "defined": "1.0.0",
+                "detective": "4.7.1",
+                "duplexer2": "0.1.4",
+                "inherits": "2.0.3",
+                "parents": "1.0.1",
+                "readable-stream": "2.3.3",
+                "resolve": "1.7.1",
+                "stream-combiner2": "1.1.1",
+                "subarg": "1.0.0",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "duplexer2": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+                    "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
                 }
             }
         },
@@ -3888,18 +5567,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-odd": "^2.0.0",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3922,6 +5601,12 @@
                 }
             }
         },
+        "nanosocket": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/nanosocket/-/nanosocket-1.1.0.tgz",
+            "integrity": "sha512-v2LsjYMRu3/JT/z8Qpkj1X5dgwCptC3D0NzeYlb7tb2qGJhlx0PSXZJraf1tRPKipj2iwB15GRzqUaOlN+LieQ==",
+            "dev": true
+        },
         "natives": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
@@ -3934,25 +5619,165 @@
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
             "dev": true
         },
+        "ngrok": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-3.0.1.tgz",
+            "integrity": "sha512-+vRPAszUa+Ni9aZhbeT/iogv9cLlr6mtekspD4Ivrtc7EnZGV6q7PIjrUZIHyfT1zpq4+yIgqW//LIgGLbaMZA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@types/node": "8.10.20",
+                "decompress-zip": "0.3.1",
+                "request": "2.87.0",
+                "request-promise-native": "1.0.5",
+                "uuid": "3.2.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+                    "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.17"
+                    },
+                    "dependencies": {
+                        "combined-stream": {
+                            "version": "1.0.6",
+                            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "delayed-stream": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "request": {
+                    "version": "2.87.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+                    "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.0.3",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.1",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.2.1"
+                    }
+                }
+            }
+        },
         "node-gyp": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
             "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
             "dev": true,
             "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.5",
+                "request": "2.81.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.0"
             },
             "dependencies": {
                 "glob": {
@@ -3961,12 +5786,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "semver": {
@@ -3983,25 +5808,25 @@
             "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
             "dev": true,
             "requires": {
-                "async-foreach": "^0.1.3",
-                "chalk": "^1.1.1",
-                "cross-spawn": "^3.0.0",
-                "gaze": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "glob": "^7.0.3",
-                "in-publish": "^2.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.clonedeep": "^4.3.2",
-                "lodash.mergewith": "^4.6.0",
-                "meow": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "nan": "^2.10.0",
-                "node-gyp": "^3.3.1",
-                "npmlog": "^4.0.0",
-                "request": "~2.79.0",
-                "sass-graph": "^2.2.4",
-                "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
+                "async-foreach": "0.1.3",
+                "chalk": "1.1.3",
+                "cross-spawn": "3.0.1",
+                "gaze": "1.1.2",
+                "get-stdin": "4.0.1",
+                "glob": "7.1.2",
+                "in-publish": "2.0.0",
+                "lodash.assign": "4.2.0",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.mergewith": "4.6.1",
+                "meow": "3.7.0",
+                "mkdirp": "0.5.1",
+                "nan": "2.10.0",
+                "node-gyp": "3.6.2",
+                "npmlog": "4.1.2",
+                "request": "2.79.0",
+                "sass-graph": "2.2.4",
+                "stdout-stream": "1.4.0",
+                "true-case-path": "1.0.2"
             },
             "dependencies": {
                 "caseless": {
@@ -4016,7 +5841,7 @@
                     "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
                     "dev": true,
                     "requires": {
-                        "globule": "^1.0.0"
+                        "globule": "1.2.0"
                     }
                 },
                 "glob": {
@@ -4025,12 +5850,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "globule": {
@@ -4039,9 +5864,9 @@
                     "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
                     "dev": true,
                     "requires": {
-                        "glob": "~7.1.1",
-                        "lodash": "~4.17.4",
-                        "minimatch": "~3.0.2"
+                        "glob": "7.1.2",
+                        "lodash": "4.17.5",
+                        "minimatch": "3.0.4"
                     }
                 },
                 "har-validator": {
@@ -4050,10 +5875,10 @@
                     "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "^1.1.1",
-                        "commander": "^2.9.0",
-                        "is-my-json-valid": "^2.12.4",
-                        "pinkie-promise": "^2.0.0"
+                        "chalk": "1.1.3",
+                        "commander": "2.13.0",
+                        "is-my-json-valid": "2.17.2",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "lodash": {
@@ -4080,26 +5905,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "~0.6.0",
-                        "aws4": "^1.2.1",
-                        "caseless": "~0.11.0",
-                        "combined-stream": "~1.0.5",
-                        "extend": "~3.0.0",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.1.1",
-                        "har-validator": "~2.0.6",
-                        "hawk": "~3.1.3",
-                        "http-signature": "~1.1.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.7",
-                        "oauth-sign": "~0.8.1",
-                        "qs": "~6.3.0",
-                        "stringstream": "~0.0.4",
-                        "tough-cookie": "~2.3.0",
-                        "tunnel-agent": "~0.4.1",
-                        "uuid": "^3.0.0"
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.2.1"
                     }
                 },
                 "tunnel-agent": {
@@ -4116,7 +5941,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
             }
         },
         "normalize-package-data": {
@@ -4125,10 +5950,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.1"
             }
         },
         "normalize-path": {
@@ -4137,7 +5962,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "npmlog": {
@@ -4146,10 +5971,10 @@
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
             }
         },
         "number-is-nan": {
@@ -4182,9 +6007,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -4193,7 +6018,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -4210,7 +6035,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -4227,10 +6052,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "^1.0.1",
-                "array-slice": "^1.0.0",
-                "for-own": "^1.0.0",
-                "isobject": "^3.0.0"
+                "array-each": "1.0.1",
+                "array-slice": "1.1.0",
+                "for-own": "1.0.0",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "for-own": {
@@ -4239,7 +6064,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "for-in": "1.0.2"
                     }
                 },
                 "isobject": {
@@ -4256,8 +6081,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "^1.0.0",
-                "make-iterator": "^1.0.0"
+                "for-own": "1.0.0",
+                "make-iterator": "1.0.1"
             },
             "dependencies": {
                 "for-own": {
@@ -4266,7 +6091,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "for-in": "1.0.2"
                     }
                 }
             }
@@ -4277,8 +6102,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "object.pick": {
@@ -4287,7 +6112,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -4307,13 +6132,19 @@
                 "ee-first": "1.1.1"
             }
         },
+        "on-headers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+            "dev": true
+        },
         "once": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
             "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "openurl": {
@@ -4328,8 +6159,8 @@
             "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
             "dev": true,
             "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
             }
         },
         "orchestrator": {
@@ -4338,15 +6169,21 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "~0.1.5",
-                "sequencify": "~0.0.7",
-                "stream-consume": "~0.1.0"
+                "end-of-stream": "0.1.5",
+                "sequencify": "0.0.7",
+                "stream-consume": "0.1.1"
             }
         },
         "ordered-read-streams": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
             "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
+            "dev": true
+        },
+        "os-browserify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+            "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
             "dev": true
         },
         "os-homedir": {
@@ -4361,7 +6198,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "^1.0.0"
+                "lcid": "1.0.0"
             }
         },
         "os-tmpdir": {
@@ -4376,8 +6213,36 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "pako": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+            "dev": true
+        },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "0.11.15"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+            "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+            "dev": true,
+            "requires": {
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.16"
             }
         },
         "parse-filepath": {
@@ -4386,9 +6251,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "^1.0.0",
-                "map-cache": "^0.2.0",
-                "path-root": "^0.1.1"
+                "is-absolute": "1.0.0",
+                "map-cache": "0.2.2",
+                "path-root": "0.1.1"
             }
         },
         "parse-glob": {
@@ -4397,10 +6262,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "parse-json": {
@@ -4409,7 +6274,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.1"
             }
         },
         "parse-passwd": {
@@ -4424,7 +6289,7 @@
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "dev": true,
             "requires": {
-                "better-assert": "~1.0.0"
+                "better-assert": "1.0.2"
             }
         },
         "parseuri": {
@@ -4433,7 +6298,7 @@
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "dev": true,
             "requires": {
-                "better-assert": "~1.0.0"
+                "better-assert": "1.0.2"
             }
         },
         "parseurl": {
@@ -4448,13 +6313,19 @@
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
         },
+        "path-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+            "dev": true
+        },
         "path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "^2.0.0"
+                "pinkie-promise": "2.0.1"
             }
         },
         "path-is-absolute": {
@@ -4469,13 +6340,19 @@
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
             "dev": true
         },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
         "path-root": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "^0.1.0"
+                "path-root-regex": "0.1.2"
             }
         },
         "path-root-regex": {
@@ -4484,15 +6361,40 @@
             "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
             "dev": true
         },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+            "dev": true
+        },
         "path-type": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
+        "pbkdf2": {
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+            "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.11"
             }
         },
         "performance-now": {
@@ -4519,8 +6421,14 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
+        },
+        "platform": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+            "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+            "dev": true
         },
         "plugin-error": {
             "version": "1.0.1",
@@ -4528,10 +6436,10 @@
             "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "^1.0.1",
-                "arr-diff": "^4.0.0",
-                "arr-union": "^3.1.0",
-                "extend-shallow": "^3.0.2"
+                "ansi-colors": "1.1.0",
+                "arr-diff": "4.0.0",
+                "arr-union": "3.1.0",
+                "extend-shallow": "3.0.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4546,8 +6454,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -4556,9 +6464,42 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
+            }
+        },
+        "popper": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/popper/-/popper-1.0.1.tgz",
+            "integrity": "sha512-i/6yRlY5+VomX0ScQ5TI4Ro8XlQbOj7NMRf0hSnUEVv/aAP6IbrxvNcRsrEG6VsKzvltfINPeD4p++6SKwOTSA==",
+            "dev": true,
+            "requires": {
+                "browser-icons": "0.0.1",
+                "browserify": "12.0.2",
+                "buble": "0.16.0",
+                "chai": "4.1.2",
+                "chokidar": "1.7.0",
+                "colors": "1.3.0",
+                "compression": "1.7.2",
+                "cryonic": "1.0.0",
+                "express": "4.16.3",
+                "js-yaml": "3.12.0",
+                "minimist": "1.2.0",
+                "mocha": "5.2.0",
+                "ngrok": "3.0.1",
+                "platform": "1.3.5",
+                "rijs": "0.9.1",
+                "rijs.core": "1.2.6",
+                "rijs.css": "1.2.4",
+                "rijs.data": "2.2.4",
+                "rijs.fn": "1.2.6",
+                "rijs.npm": "2.0.0",
+                "rijs.resdir": "1.4.4",
+                "rijs.sync": "2.3.5",
+                "serve-static": "1.13.2",
+                "utilise": "2.3.7",
+                "wd": "1.9.0"
             }
         },
         "portscanner": {
@@ -4568,7 +6509,7 @@
             "dev": true,
             "requires": {
                 "async": "1.5.2",
-                "is-number-like": "^1.0.3"
+                "is-number-like": "1.0.8"
             }
         },
         "posix-character-classes": {
@@ -4589,11 +6530,27 @@
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
             "dev": true
         },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
         "process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
             "dev": true
+        },
+        "proxy-addr": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+            "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+            "dev": true,
+            "requires": {
+                "forwarded": "0.1.2",
+                "ipaddr.js": "1.6.0"
+            }
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -4601,16 +6558,54 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
+        "public-encrypt": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+            "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.1",
+                "randombytes": "2.0.6"
+            }
+        },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true,
+            "optional": true
+        },
         "qs": {
             "version": "6.2.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
             "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "random-bytes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+            "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
             "dev": true
         },
         "randomatic": {
@@ -4619,8 +6614,8 @@
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -4629,7 +6624,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4638,7 +6633,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -4649,9 +6644,28 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1"
             }
         },
         "range-parser": {
@@ -4672,15 +6686,24 @@
                 "unpipe": "1.0.0"
             }
         },
+        "read-only-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
         "read-pkg": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
             }
         },
         "read-pkg-up": {
@@ -4689,8 +6712,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
             }
         },
         "readable-stream": {
@@ -4699,13 +6722,13 @@
             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.0.3",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
             },
             "dependencies": {
                 "isarray": {
@@ -4722,10 +6745,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "readable-stream": "^2.0.2",
-                "set-immediate-shim": "^1.0.1"
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.3",
+                "set-immediate-shim": "1.0.1"
             }
         },
         "rechoir": {
@@ -4734,7 +6757,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "^1.1.6"
+                "resolve": "1.7.1"
             }
         },
         "redent": {
@@ -4743,8 +6766,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
             }
         },
         "regex-cache": {
@@ -4753,7 +6776,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -4762,8 +6785,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "remove-trailing-separator": {
@@ -4790,7 +6813,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "^1.0.0"
+                "is-finite": "1.0.2"
             }
         },
         "replace-ext": {
@@ -4805,28 +6828,28 @@
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
             },
             "dependencies": {
                 "qs": {
@@ -4835,6 +6858,37 @@
                     "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                     "dev": true
                 }
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "lodash": "4.17.10"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
             }
         },
         "require-directory": {
@@ -4861,7 +6915,7 @@
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "resolve-dir": {
@@ -4870,8 +6924,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
             }
         },
         "resolve-url": {
@@ -4886,8 +6940,8 @@
             "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
             "dev": true,
             "requires": {
-                "debug": "^2.2.0",
-                "minimatch": "^3.0.2"
+                "debug": "2.6.9",
+                "minimatch": "3.0.4"
             }
         },
         "ret": {
@@ -4896,13 +6950,258 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
-        "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+        "rijs": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/rijs/-/rijs-0.9.1.tgz",
+            "integrity": "sha512-Hl5yWFZUdVePXIOHRrFXGxQZ2+fzWucqqx/aQjkE0PxbmNyOY0WA/SWdDA1eKeqb7lh2a0vcchR9mZLiQ9rHFQ==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "rijs.components": "3.1.16",
+                "rijs.core": "1.2.6",
+                "rijs.css": "1.2.4",
+                "rijs.data": "2.2.4",
+                "rijs.fn": "1.2.6",
+                "rijs.pages": "1.3.0",
+                "rijs.resdir": "1.4.4",
+                "rijs.serve": "1.1.1",
+                "rijs.sessions": "1.1.2",
+                "rijs.singleton": "1.0.0",
+                "rijs.sync": "2.3.5",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.components": {
+            "version": "3.1.16",
+            "resolved": "https://registry.npmjs.org/rijs.components/-/rijs.components-3.1.16.tgz",
+            "integrity": "sha512-7TneWZIILv20erfzKtU1xnwtFSxiB+/9rwdS/3WGkugUbaXZF811kNfvaOlE4+BEj08CV8o0Dkasih3p4NV/dw==",
+            "dev": true,
+            "requires": {
+                "@compone/define": "1.2.4",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.core": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/rijs.core/-/rijs.core-1.2.6.tgz",
+            "integrity": "sha512-bB/tay726eZomQe91ciIuSGM1zDNyIuOkKdg6jRvYOGR8N30x5qHoADVgCEJgpgqlsPjmuBq6qPsJ3Pw4Nv6Uw==",
+            "dev": true,
+            "requires": {
+                "colors": "1.3.0",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.css": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/rijs.css/-/rijs.css-1.2.4.tgz",
+            "integrity": "sha512-2VKq0iWFki9gZMntUCoOCJVxn/o7tOZu7L0MzD7srPKiynaTsk8A7PjTwFmds1vdJ995v8adg3ax0eS5i+Jbow==",
+            "dev": true,
+            "requires": {
+                "djbx": "1.0.3",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.data": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/rijs.data/-/rijs.data-2.2.4.tgz",
+            "integrity": "sha512-zvR1GzRzcqZOeD7K+YVV7MmvLeLFbrLsrkxkEW570WiLQsnjTaZ6hLnftXlHLnPMWMIrGfs8gh6BJLWY3XcjXA==",
+            "dev": true,
+            "requires": {
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.fn": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/rijs.fn/-/rijs.fn-1.2.6.tgz",
+            "integrity": "sha512-v/xM7OOzS8HXqGA0y9ey/D0YOyAjiujKJT17/4U0CqViVhMi+0AsJCSuJqSMS4CkzLpy3CqdgKkRD6hnet3i+w==",
+            "dev": true,
+            "requires": {
+                "browser-resolve": "1.11.3",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.npm": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/rijs.npm/-/rijs.npm-2.0.0.tgz",
+            "integrity": "sha512-xRg5+MH0H5fDe9aMi68xZHq3E6AH1+fouGIJ+a7uFoirnbYdP9YqMK3QYFnvslF0Is08Rhx/R9P/7vwpI1N4rg==",
+            "dev": true,
+            "requires": {
+                "browser-resolve": "1.11.3",
+                "browserify": "14.5.0",
+                "find-package-json": "1.1.0",
+                "utilise": "2.3.7"
+            },
+            "dependencies": {
+                "assert": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+                    "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+                    "dev": true,
+                    "requires": {
+                        "util": "0.10.3"
+                    },
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                            "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                            "dev": true
+                        },
+                        "util": {
+                            "version": "0.10.3",
+                            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                            "dev": true,
+                            "requires": {
+                                "inherits": "2.0.1"
+                            }
+                        }
+                    }
+                },
+                "base64-js": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+                    "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+                    "dev": true
+                },
+                "browserify": {
+                    "version": "14.5.0",
+                    "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
+                    "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "1.3.3",
+                        "assert": "1.4.1",
+                        "browser-pack": "6.1.0",
+                        "browser-resolve": "1.11.3",
+                        "browserify-zlib": "0.2.0",
+                        "buffer": "5.1.0",
+                        "cached-path-relative": "1.0.1",
+                        "concat-stream": "1.5.2",
+                        "console-browserify": "1.1.0",
+                        "constants-browserify": "1.0.0",
+                        "crypto-browserify": "3.12.0",
+                        "defined": "1.0.0",
+                        "deps-sort": "2.0.0",
+                        "domain-browser": "1.1.7",
+                        "duplexer2": "0.1.4",
+                        "events": "1.1.1",
+                        "glob": "7.1.2",
+                        "has": "1.0.3",
+                        "htmlescape": "1.1.1",
+                        "https-browserify": "1.0.0",
+                        "inherits": "2.0.3",
+                        "insert-module-globals": "7.2.0",
+                        "labeled-stream-splicer": "2.0.1",
+                        "module-deps": "4.1.1",
+                        "os-browserify": "0.3.0",
+                        "parents": "1.0.1",
+                        "path-browserify": "0.0.1",
+                        "process": "0.11.10",
+                        "punycode": "1.4.1",
+                        "querystring-es3": "0.2.1",
+                        "read-only-stream": "2.0.0",
+                        "readable-stream": "2.3.3",
+                        "resolve": "1.7.1",
+                        "shasum": "1.0.2",
+                        "shell-quote": "1.6.1",
+                        "stream-browserify": "2.0.1",
+                        "stream-http": "2.8.3",
+                        "string_decoder": "1.0.3",
+                        "subarg": "1.0.0",
+                        "syntax-error": "1.4.0",
+                        "through2": "2.0.3",
+                        "timers-browserify": "1.4.2",
+                        "tty-browserify": "0.0.1",
+                        "url": "0.11.0",
+                        "util": "0.10.4",
+                        "vm-browserify": "0.0.4",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "browserify-zlib": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+                    "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+                    "dev": true,
+                    "requires": {
+                        "pako": "1.0.6"
+                    }
+                },
+                "buffer": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+                    "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "1.3.0",
+                        "ieee754": "1.1.12"
+                    }
+                },
+                "duplexer2": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+                    "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "https-browserify": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+                    "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+                    "dev": true
+                },
+                "os-browserify": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+                    "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+                    "dev": true
+                },
+                "pako": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+                    "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+                    "dev": true
+                }
+            }
+        },
+        "rijs.pages": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rijs.pages/-/rijs.pages-1.3.0.tgz",
+            "integrity": "sha512-230MZ7oyDVPoTBQSHuA3vqawikFgRtvoVRaRq7utWPpbo7NpDO7TaOsJmzM66WPypMXStH5ijyFADXwrqYJvdg==",
+            "dev": true,
+            "requires": {
+                "compression": "1.7.2",
+                "express": "4.16.3",
+                "serve-static": "1.13.2",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.resdir": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/rijs.resdir/-/rijs.resdir-1.4.4.tgz",
+            "integrity": "sha512-l31HSXq13Rqaxr5wfY4d2MBFdTwmgG1A/FxGNrBc31E2WgBe4Hj86LhnRQage4SN8RjVZnf1JWWakbS7BVfoBw==",
+            "dev": true,
+            "requires": {
+                "chokidar": "1.7.0",
+                "glob": "7.1.2",
+                "minimist": "1.2.0",
+                "utilise": "2.3.7"
             },
             "dependencies": {
                 "glob": {
@@ -4911,14 +7210,148 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
+            }
+        },
+        "rijs.serve": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/rijs.serve/-/rijs.serve-1.1.1.tgz",
+            "integrity": "sha512-BZ4tNnMakHvfv0pLVLm1xtN7fncAnux5n57A1RsFOma1Y2wexM/ww8BHwQrsCkSYP+3ujfljthyb1J3HJGwXpA==",
+            "dev": true,
+            "requires": {
+                "compression": "1.7.2",
+                "express": "4.16.3",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.sessions": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/rijs.sessions/-/rijs.sessions-1.1.2.tgz",
+            "integrity": "sha512-vj9iV8ov5awAnDy5x28FEezafbMClO/1JhnBIIsQg9DQ5vQBysPlwyiSHtNelXmE9gFbaxnsPD1/mUc3hm3FsQ==",
+            "dev": true,
+            "requires": {
+                "cookie-parser": "1.4.3",
+                "express-session": "1.15.6",
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.singleton": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/rijs.singleton/-/rijs.singleton-1.0.0.tgz",
+            "integrity": "sha512-QeVEkimxkU0v06NnMYkKsj7R2AzFewG2FH1wMuUtO88n7gY7C/zdbFkNbYeWxqL+tuK+eLYWGFuoburTNM7rXQ==",
+            "dev": true,
+            "requires": {
+                "utilise": "2.3.7"
+            }
+        },
+        "rijs.sync": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/rijs.sync/-/rijs.sync-2.3.5.tgz",
+            "integrity": "sha512-tcbhmjLyWb+2s2gdiSmROEoD/OQPFeKC9xBnKgs0H+umY8CaVrVPGFdr1y1qovm7HxUbdk/BKqi94GQDc5XB3A==",
+            "dev": true,
+            "requires": {
+                "buble": "github:pemrouz/buble#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
+                "express": "4.16.3",
+                "lru_map": "0.3.3",
+                "platform": "1.3.5",
+                "utilise": "2.3.7",
+                "xrs": "1.2.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "buble": {
+                    "version": "github:pemrouz/buble#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "5.7.1",
+                        "acorn-jsx": "3.0.1",
+                        "acorn5-object-spread": "4.0.0",
+                        "chalk": "2.4.1",
+                        "magic-string": "0.22.5",
+                        "minimist": "1.2.0",
+                        "os-homedir": "1.0.2",
+                        "vlq": "0.2.3"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "magic-string": {
+                    "version": "0.22.5",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+                    "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+                    "dev": true,
+                    "requires": {
+                        "vlq": "0.2.3"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
+                    }
+                }
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "rx": {
@@ -4939,7 +7372,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "sass-graph": {
@@ -4948,10 +7381,10 @@
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "lodash": "^4.0.0",
-                "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "scss-tokenizer": "0.2.3",
+                "yargs": "7.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -4966,12 +7399,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "lodash": {
@@ -4986,19 +7419,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -5007,7 +7440,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "3.0.0"
                     }
                 }
             }
@@ -5018,8 +7451,8 @@
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "^2.1.8",
-                "source-map": "^0.4.2"
+                "js-base64": "2.4.3",
+                "source-map": "0.4.4"
             },
             "dependencies": {
                 "source-map": {
@@ -5028,7 +7461,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -5046,18 +7479,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
+                "http-errors": "1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.4.0"
             },
             "dependencies": {
                 "depd": {
@@ -5086,13 +7519,13 @@
             "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.3",
+                "accepts": "1.3.5",
                 "batch": "0.5.3",
-                "debug": "~2.2.0",
-                "escape-html": "~1.0.3",
-                "http-errors": "~1.5.0",
-                "mime-types": "~2.1.11",
-                "parseurl": "~1.3.1"
+                "debug": "2.2.0",
+                "escape-html": "1.0.3",
+                "http-errors": "1.5.1",
+                "mime-types": "2.1.17",
+                "parseurl": "1.3.2"
             },
             "dependencies": {
                 "debug": {
@@ -5112,7 +7545,7 @@
                     "requires": {
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.2",
-                        "statuses": ">= 1.3.1 < 2"
+                        "statuses": "1.3.1"
                     }
                 },
                 "ms": {
@@ -5135,9 +7568,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -5165,10 +7598,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5177,7 +7610,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -5187,6 +7620,49 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
             "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
             "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "shasum": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "0.0.1",
+                "sha.js": "2.4.11"
+            },
+            "dependencies": {
+                "json-stable-stringify": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                    "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+                    "dev": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                }
+            }
+        },
+        "shell-quote": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "dev": true,
+            "requires": {
+                "array-filter": "0.0.1",
+                "array-map": "0.0.0",
+                "array-reduce": "0.0.0",
+                "jsonify": "0.0.0"
+            }
         },
         "sigmund": {
             "version": "1.0.1",
@@ -5200,20 +7676,26 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "simple-concat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+            "dev": true
+        },
         "snapdragon": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.1",
+                "use": "3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5222,7 +7704,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -5231,7 +7713,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -5242,9 +7724,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -5253,7 +7735,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5262,7 +7744,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -5271,7 +7753,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -5280,9 +7762,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -5305,7 +7787,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             }
         },
         "sntp": {
@@ -5314,7 +7796,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "socket.io": {
@@ -5323,11 +7805,11 @@
             "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
             "dev": true,
             "requires": {
-                "debug": "~2.6.6",
-                "engine.io": "~3.1.0",
-                "socket.io-adapter": "~1.1.0",
+                "debug": "2.6.9",
+                "engine.io": "3.1.5",
+                "socket.io-adapter": "1.1.1",
                 "socket.io-client": "2.0.4",
-                "socket.io-parser": "~3.1.1"
+                "socket.io-parser": "3.1.3"
             }
         },
         "socket.io-adapter": {
@@ -5346,14 +7828,14 @@
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "~2.6.4",
-                "engine.io-client": "~3.1.0",
+                "debug": "2.6.9",
+                "engine.io-client": "3.1.6",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.1.1",
+                "socket.io-parser": "3.1.3",
                 "to-array": "0.1.4"
             }
         },
@@ -5364,8 +7846,8 @@
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
-                "has-binary2": "~1.0.2",
+                "debug": "3.1.0",
+                "has-binary2": "1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -5392,11 +7874,11 @@
             "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "^2.0.0",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.1",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-url": {
@@ -5417,7 +7899,7 @@
             "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
             "dev": true,
             "requires": {
-                "spdx-license-ids": "^1.0.2"
+                "spdx-license-ids": "1.2.2"
             }
         },
         "spdx-expression-parse": {
@@ -5438,8 +7920,14 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
         },
         "sshpk": {
             "version": "1.13.1",
@@ -5447,14 +7935,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5471,8 +7959,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5481,7 +7969,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -5498,7 +7986,45 @@
             "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.3"
+            }
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true,
+            "optional": true
+        },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.1.4",
+                "readable-stream": "2.3.3"
+            },
+            "dependencies": {
+                "duplexer2": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+                    "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "2.3.3"
+                    }
+                }
             }
         },
         "stream-consume": {
@@ -5507,14 +8033,75 @@
             "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
             "dev": true
         },
+        "stream-http": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+            "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "stream-splicer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+            "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "stream-throttle": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
             "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
             "dev": true,
             "requires": {
-                "commander": "^2.2.0",
-                "limiter": "^1.0.5"
+                "commander": "2.13.0",
+                "limiter": "1.1.3"
             }
         },
         "string-width": {
@@ -5523,9 +8110,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
             }
         },
         "string_decoder": {
@@ -5534,7 +8121,7 @@
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
             }
         },
         "stringstream": {
@@ -5549,7 +8136,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -5558,7 +8145,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-indent": {
@@ -5567,7 +8154,16 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "^4.0.1"
+                "get-stdin": "4.0.1"
+            }
+        },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0"
             }
         },
         "supports-color": {
@@ -5576,15 +8172,59 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "syntax-error": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+            "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "1.5.2"
+            }
+        },
         "tar": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
+        },
+        "tar-stream": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+            "dev": true,
+            "requires": {
+                "bl": "1.2.2",
+                "buffer-alloc": "1.2.0",
+                "end-of-stream": "1.4.1",
+                "fs-constants": "1.0.0",
+                "readable-stream": "2.3.3",
+                "to-buffer": "1.1.1",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                    "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0"
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                }
             }
         },
         "tfunk": {
@@ -5593,9 +8233,15 @@
             "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.1",
-                "object-path": "^0.9.0"
+                "chalk": "1.1.3",
+                "object-path": "0.9.2"
             }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
         },
         "through2": {
             "version": "2.0.3",
@@ -5603,8 +8249,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
             }
         },
         "tildify": {
@@ -5613,7 +8259,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0"
+                "os-homedir": "1.0.2"
             }
         },
         "time-stamp": {
@@ -5622,10 +8268,31 @@
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
         },
+        "timers-browserify": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+            "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+            "dev": true,
+            "requires": {
+                "process": "0.11.10"
+            }
+        },
         "to-array": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
             "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+            "dev": true
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "to-buffer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
             "dev": true
         },
         "to-object-path": {
@@ -5634,7 +8301,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "to-regex": {
@@ -5643,10 +8310,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -5655,8 +8322,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -5665,7 +8332,29 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
+                    }
+                }
+            }
+        },
+        "touch": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+            "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nopt": "1.0.10"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                    "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.1"
                     }
                 }
             }
@@ -5676,8 +8365,15 @@
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "dev": true,
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             }
+        },
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+            "dev": true,
+            "optional": true
         },
         "trim-newlines": {
             "version": "1.0.0",
@@ -5691,7 +8387,7 @@
             "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
             "dev": true,
             "requires": {
-                "glob": "^6.0.4"
+                "glob": "6.0.4"
             },
             "dependencies": {
                 "glob": {
@@ -5700,14 +8396,20 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.3.3",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
+        },
+        "tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -5715,7 +8417,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "tweetnacl": {
@@ -5724,6 +8426,45 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true,
             "optional": true
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
+        "type-is": {
+            "version": "1.6.16",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.18"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.18",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+                    "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.33.0"
+                    }
+                }
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
         },
         "ua-parser-js": {
             "version": "0.7.17",
@@ -5737,8 +8478,8 @@
             "integrity": "sha512-J2t8B5tj9JdPTW4+sNZXmiIWHzTvcoITkaqzTiilu/biZF/9crqf/Fi7k5hqbOmVRh9/hVNxAxBYIMF7N6SqMQ==",
             "dev": true,
             "requires": {
-                "commander": "~2.13.0",
-                "source-map": "~0.6.1"
+                "commander": "2.13.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -5749,10 +8490,25 @@
                 }
             }
         },
+        "uid-safe": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+            "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+            "dev": true,
+            "requires": {
+                "random-bytes": "1.0.0"
+            }
+        },
         "ultron": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+            "dev": true
+        },
+        "umd": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+            "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
             "dev": true
         },
         "unc-path-regex": {
@@ -5761,16 +8517,38 @@
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
             "dev": true
         },
+        "undeclared-identifiers": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
+            "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "1.5.2",
+                "get-assigned-identifiers": "1.2.0",
+                "simple-concat": "1.0.0",
+                "xtend": "4.0.1"
+            }
+        },
+        "underscore.string": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+            "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
         "union-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5779,7 +8557,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -5788,10 +8566,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -5820,8 +8598,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -5830,9 +8608,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -5872,13 +8650,31 @@
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
             "dev": true
         },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
         "use": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5895,11 +8691,30 @@
             "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
             "dev": true
         },
+        "util": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
+        },
+        "utilise": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/utilise/-/utilise-2.3.7.tgz",
+            "integrity": "sha512-IjGNAQE7txhJI8avL0Vfu6sGwwuMyXhNyO73quQQD3U0ofA4fjjovuAaQvxVuJ3e1wvqVV13VLeuEjsjGv+Jmg==",
+            "dev": true,
+            "requires": {
+                "colors": "1.3.0",
+                "through": "2.3.8"
+            }
         },
         "utils-merge": {
             "version": "1.0.0",
@@ -5926,7 +8741,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "^1.1.1"
+                "user-home": "1.1.1"
             }
         },
         "validate-npm-package-license": {
@@ -5935,9 +8750,21 @@
             "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
             "dev": true,
             "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
             }
+        },
+        "vargs": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+            "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+            "dev": true
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
         },
         "verror": {
             "version": "1.10.0",
@@ -5945,9 +8772,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5964,8 +8791,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
+                "clone": "1.0.4",
+                "clone-stats": "0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -5975,14 +8802,14 @@
             "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
             "dev": true,
             "requires": {
-                "defaults": "^1.0.0",
-                "glob-stream": "^3.1.5",
-                "glob-watcher": "^0.0.6",
-                "graceful-fs": "^3.0.0",
-                "mkdirp": "^0.5.0",
-                "strip-bom": "^1.0.0",
-                "through2": "^0.6.1",
-                "vinyl": "^0.4.0"
+                "defaults": "1.0.3",
+                "glob-stream": "3.1.18",
+                "glob-watcher": "0.0.6",
+                "graceful-fs": "3.0.11",
+                "mkdirp": "0.5.1",
+                "strip-bom": "1.0.0",
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -5997,7 +8824,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "^1.1.0"
+                        "natives": "1.1.3"
                     }
                 },
                 "isarray": {
@@ -6012,10 +8839,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -6030,8 +8857,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "^1.0.0",
-                        "is-utf8": "^0.2.0"
+                        "first-chunk-stream": "1.0.0",
+                        "is-utf8": "0.2.1"
                     }
                 },
                 "through2": {
@@ -6040,8 +8867,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 },
                 "vinyl": {
@@ -6050,8 +8877,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -6062,7 +8889,232 @@
             "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.1"
+                "source-map": "0.5.7"
+            }
+        },
+        "vlq": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+            "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+            "dev": true
+        },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "dev": true,
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
+        "wd": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/wd/-/wd-1.9.0.tgz",
+            "integrity": "sha512-etqaVS5YFPuwaBRXNFnG0UIoCJHIPoWbVgdbK0v8MQRPQx2sNJc/wu0cRzLEuQjhGt/b0NGxcO1CvA5IAqoWrg==",
+            "dev": true,
+            "requires": {
+                "archiver": "2.1.1",
+                "async": "2.0.1",
+                "lodash": "4.17.10",
+                "mkdirp": "0.5.1",
+                "q": "1.4.1",
+                "request": "2.85.0",
+                "underscore.string": "3.3.4",
+                "vargs": "0.1.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "async": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                    "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "4.17.10"
+                    }
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "boom": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                },
+                "cryptiles": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "5.2.0"
+                    },
+                    "dependencies": {
+                        "boom": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                            "dev": true,
+                            "requires": {
+                                "hoek": "4.2.1"
+                            }
+                        }
+                    }
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+                    "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.17"
+                    },
+                    "dependencies": {
+                        "combined-stream": {
+                            "version": "1.0.6",
+                            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+                            "dev": true,
+                            "requires": {
+                                "delayed-stream": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "hawk": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+                    "dev": true,
+                    "requires": {
+                        "boom": "4.3.1",
+                        "cryptiles": "3.1.2",
+                        "hoek": "4.2.1",
+                        "sntp": "2.1.0"
+                    }
+                },
+                "hoek": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+                    "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+                    "dev": true
+                },
+                "q": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                    "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.85.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+                    "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.0.3",
+                        "hawk": "6.0.2",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.2.1"
+                    }
+                },
+                "sntp": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                }
             }
         },
         "which": {
@@ -6071,7 +9123,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -6086,7 +9138,7 @@
             "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.2"
+                "string-width": "1.0.2"
             }
         },
         "window-size": {
@@ -6101,8 +9153,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             }
         },
         "wrappy": {
@@ -6117,9 +9169,9 @@
             "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
             }
         },
         "xmlhttprequest-ssl": {
@@ -6127,6 +9179,27 @@
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
             "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
             "dev": true
+        },
+        "xrs": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/xrs/-/xrs-1.2.2.tgz",
+            "integrity": "sha512-pLmxYQnG3Qm0xtZZMFr7W7ls9DYNtNe9D5KLQpniu3DeoHDMkFXrjo8OjCEyhQ3Pf4Jr/pYFDhuMrQVTfEqEOw==",
+            "dev": true,
+            "requires": {
+                "colors": "1.3.0",
+                "express": "4.16.3",
+                "nanosocket": "1.1.0",
+                "utilise": "2.3.7",
+                "uws": "9.148.0"
+            },
+            "dependencies": {
+                "uws": {
+                    "version": "9.148.0",
+                    "resolved": "https://registry.npmjs.org/uws/-/uws-9.148.0.tgz",
+                    "integrity": "sha512-vWt+e8dOdwLM4neb1xIeZuQ7ZUN3l7n0qTKrOUtU1EZrV4BpmrSnsEL30d062/ocqRMGtLpwzVFsLKFgXomA9g==",
+                    "dev": true
+                }
+            }
         },
         "xtend": {
             "version": "4.0.1",
@@ -6152,20 +9225,20 @@
             "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
             "dev": true,
             "requires": {
-                "camelcase": "^3.0.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^1.4.0",
-                "read-pkg-up": "^1.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^1.0.2",
-                "which-module": "^1.0.0",
-                "window-size": "^0.2.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^4.1.0"
+                "camelcase": "3.0.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "window-size": "0.2.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "4.2.1"
             }
         },
         "yargs-parser": {
@@ -6174,7 +9247,7 @@
             "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
             "dev": true,
             "requires": {
-                "camelcase": "^3.0.0"
+                "camelcase": "3.0.0"
             }
         },
         "yeast": {
@@ -6182,6 +9255,26 @@
             "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
             "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
             "dev": true
+        },
+        "zip-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+            "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+            "dev": true,
+            "requires": {
+                "archiver-utils": "1.3.0",
+                "compress-commons": "1.2.2",
+                "lodash": "4.17.10",
+                "readable-stream": "2.3.3"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+                    "dev": true
+                }
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,6 +789,14 @@
             "dev": true,
             "requires": {
                 "hoek": "2.16.3"
+            },
+            "dependencies": {
+                "hoek": {
+                    "version": "2.16.3",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                    "dev": true
+                }
             }
         },
         "bootstrap": {
@@ -4249,6 +4257,14 @@
                 "cryptiles": "2.0.5",
                 "hoek": "2.16.3",
                 "sntp": "1.0.9"
+            },
+            "dependencies": {
+                "hoek": {
+                    "version": "2.16.3",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                    "dev": true
+                }
             }
         },
         "he": {
@@ -4267,12 +4283,6 @@
                 "minimalistic-assert": "1.0.1",
                 "minimalistic-crypto-utils": "1.0.1"
             }
-        },
-        "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-            "dev": true
         },
         "homedir-polyfill": {
             "version": "1.0.1",
@@ -6502,6 +6512,11 @@
                 "wd": "1.9.0"
             }
         },
+        "popper.js": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+            "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
+        },
         "portscanner": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
@@ -7797,6 +7812,14 @@
             "dev": true,
             "requires": {
                 "hoek": "2.16.3"
+            },
+            "dependencies": {
+                "hoek": {
+                    "version": "2.16.3",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                    "dev": true
+                }
             }
         },
         "socket.io": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
         "gulp": "^3.9.1",
         "gulp-clean-css": "3.9.4",
         "gulp-header": "2.0.5",
-        "gulp-rename": "^1.2.2",
+        "gulp-rename": "^1.3.0",
         "gulp-sass": "4.0.1",
-        "gulp-uglify": "3.0.0"
+        "gulp-uglify": "3.0.0",
+        "popper": "^1.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "dependencies": {
         "bootstrap": "4.1.1",
         "font-awesome": "4.7.0",
-        "jquery": "3.3.1",
-        "jquery.easing": "^1.4.1"
+        "jquery": "^3.3.1",
+        "jquery.easing": "^1.4.1",
+        "popper.js": "^1.14.3"
     },
     "devDependencies": {
         "browser-sync": "2.24.3",


### PR DESCRIPTION
Hoek dependency version had security warning through github, so I upgraded to hoek@5.

Also added popp.js peer dependency for Bootstrap for no other reason than the fact that without it, NPM throws an unsightly error message when you npm install