### PR TITLE
Remove exclusion of js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,8 +84,6 @@ function js() {
     .src([
       './js/*.js',
       '!./js/*.min.js',
-      '!./js/contact_me.js',
-      '!./js/jqBootstrapValidation.js'
     ])
     .pipe(uglify())
     .pipe(header(banner, {


### PR DESCRIPTION
Hello,

It seems that these files should not be excluded from gulp source so that minified versions would be created.

Regards,
Rokas