### PR TITLE
Make "Be Part Of Our Story" responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,11 +272,19 @@
                 </div>
               </div>
             </li>
-            <li class="timeline-inverted">
+            <li class="timeline">
               <div class="timeline-image">
-                <h4>Be Part
+                <h4 class="d-none d-lg-block">
+                  Be Part
                   <br>Of Our
                   <br>Story!</h4>
+              </div>
+              <div class="timeline-panel d-lg-none">
+                <div class="timeline-heading">
+                  <h4>
+                  Be Part Of
+                  <br>Our Story!</h4>
+                </div>
               </div>
             </li>
           </ul>


### PR DESCRIPTION
The circle with the text "Be Part Of Our Story" in the ABOUT section was not responsive, as the text was too small in small devices. Put it outside the circle in small devices to make it easier to read.

Fixes https://github.com/BlackrockDigital/startbootstrap-agency/issues/240

# Before

![image](https://user-images.githubusercontent.com/16052290/73982957-4e8fd500-4903-11ea-9fa2-e4312ec2522f.png)

# After

![image](https://user-images.githubusercontent.com/16052290/73982987-610a0e80-4903-11ea-8840-a36423d8ba5e.png)

![image](https://user-images.githubusercontent.com/16052290/73983006-6d8e6700-4903-11ea-9f46-018e9589023b.png)

# Big devices both before and after

![image](https://user-images.githubusercontent.com/16052290/73983034-7da64680-4903-11ea-9c01-47814a4424da.png)
