### PR TITLE
fixed wrong grid break point in team members

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-sm-4">
+        <div class="col-lg-4">
           <div class="team-member">
             <img class="mx-auto rounded-circle" src="img/team/1.jpg" alt="">
             <h4>Kay Garland</h4>
@@ -319,7 +319,7 @@
             </ul>
           </div>
         </div>
-        <div class="col-sm-4">
+        <div class="col-lg-4">
           <div class="team-member">
             <img class="mx-auto rounded-circle" src="img/team/2.jpg" alt="">
             <h4>Larry Parker</h4>
@@ -343,7 +343,7 @@
             </ul>
           </div>
         </div>
-        <div class="col-sm-4">
+        <div class="col-lg-4">
           <div class="team-member">
             <img class="mx-auto rounded-circle" src="img/team/3.jpg" alt="">
             <h4>Diana Pertersen</h4>


### PR DESCRIPTION
Hey there, I hope PRs are welcome in this repository but anyway I noticed a little "bug" with the BS4 grid system for team members. AFAIK the wrong device breakpoint is used. We should not use `sm-`  but rather `lg-`. Please take a look at the screenshot which shows the comparison for e.g. `631px` which looks not quite well with the old `sm-` class attribution. 

**Old grid before PR:**
![sm-4-fix fw](https://user-images.githubusercontent.com/17965908/76833186-2f059980-682b-11ea-91a9-0627d8da63e1.png)

**New grid after PR:**
![lg-4-fix fw](https://user-images.githubusercontent.com/17965908/76833150-1f865080-682b-11ea-850e-a23b73106cc7.png)

