### PR TITLE
fixed cross hover portfolio alignment

### DIFF
--- a/scss/layout/_portfolio.scss
+++ b/scss/layout/_portfolio.scss
@@ -27,7 +27,7 @@
           top: 50%;
           width: 100%;
           height: 20px;
-          margin-top: -12px;
+          margin-top: -18px;
           text-align: center;
           color: white;
           i {


### PR DESCRIPTION
Hey there, during implementation of lazy loading (with a centered spinner) I noticed that the cross overlay in the portfolio section for images is off by about 6px vertically. Hence I modified the offset from `-12px`  to `-18px`. Now it is aligned correctly (centered). Take a look at my screenshots which show the before and after results. Feel free to close if this PR does not cover your intention.

**Before:**
![cross-middle-before fw](https://user-images.githubusercontent.com/17965908/76941340-2335d800-68fc-11ea-925e-6f5d4ba1aa3b.png)

**After:** 
![cross-middle after fw](https://user-images.githubusercontent.com/17965908/76941129-c508f500-68fb-11ea-88e4-1145edb94d54.png)
